### PR TITLE
$PROMPT_COMMAND is no longer clobbered

### DIFF
--- a/bin/pyenv-autoenv
+++ b/bin/pyenv-autoenv
@@ -49,7 +49,10 @@ function _autoenv_activate() {
     _virtualenv_auto_activate
 }
 
-export PROMPT_COMMAND=_autoenv_activate
+if [[ $PROMPT_COMMAND =~ ^.*\;[[:space:]$'\n'$'\r']*$ ]]; then
+    export PROMPT_COMMAND="${PROMPT_COMMAND%;*}; "
+fi
+export PROMPT_COMMAND="$([[ $PROMPT_COMMAND ]] && echo "${PROMPT_COMMAND}; ")_autoenv_activate"
 if [ -n "$ZSH_VERSION" ]; then
   function chpwd() {
     _autoenv_activate


### PR DESCRIPTION
I wrote this because I like pyenv-autoenv, but it was clobbering the default $PROMPT_COMMAND value on OS X!
