### PR TITLE
skip installation for system python environments

### DIFF
--- a/bin/pyenv-autoenv
+++ b/bin/pyenv-autoenv
@@ -10,7 +10,7 @@
 function _python_version_auto_install() {
     if [ -e ".python-version" ];then
         _PY_VERSION=$(cat .python-version)
-        if [ ! -d "$PYENV_ROOT/versions/$_PY_VERSION" ];then
+        if [ "$_PY_VERSION" != "system" -a ! -d "$PYENV_ROOT/versions/$_PY_VERSION" ];then
             echo "Installing Python $_PY_VERSION"
             pyenv install $_PY_VERSION
             pyenv rehash


### PR DESCRIPTION
short-circuit the python installation check if the version specified is "system".

since the system python is not managed by pyenv (ergo not found in PYENV_ROOT/versions), pyenv-autoenv was unnecessarily trying, and failing, to install it.

thanks for pyenv-autoenv! :smile: 